### PR TITLE
Using a static resource path instead of a dynamic one

### DIFF
--- a/external_files.csv
+++ b/external_files.csv
@@ -1,2 +1,2 @@
 Path, URL, Size in bytes (optional but recommended), MD5 Hash (optional but recommended), Filter Terms (optional)
-retrospy/retrospy,https://github.com/retrospy/RetroSpy/releases/latest/download/retrospy,,,
+retrospy/retrospy,https://github.com/retrospy/RetroSpy/releases/download/v6.4.3/retrospy,,,


### PR DESCRIPTION
Should not use 'latest' directly since it's going to point to different versions over time. The path instead should be static so that the automatically calculated parameters 'size'/'hash', which are used for download validation, are always correct and deterministic.

Instead, you'd need to use the version explicitly, as you see in my PR, and update the version slug right there after you release a new one.